### PR TITLE
Customise packager details

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - mkdir packages
     - echo $RSA_PUBLIC_KEY > packages/sgerrand.rsa.pub
   override:
-    - docker run -e RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" -v $(pwd):/home/builder/package -v $(pwd)/packages:/home/builder/packages andyshinn/alpine-abuild
+    - docker run -e PACKAGER="Sasha Gerrand <alpine-pkg-R@sgerrand.com>" -e RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" -v $(pwd):/home/builder/package -v $(pwd)/packages:/home/builder/packages andyshinn/alpine-abuild
 
 test:
   override:


### PR DESCRIPTION
:information_desk_person: Avoid [defaulting the packager name to "Glider Labs"](https://github.com/andyshinn/docker-alpine-abuild/blob/master/README.md#environment) by setting a `PACKAGER` environment variable.
