### PR TITLE
Build R with static library support

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -37,6 +37,7 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
+		--enable-R-static-lib \
 		--disable-java \
 		--without-x \
 		|| return 1


### PR DESCRIPTION
💁  Programs like [`Rserve`](http://www.rforge.net/Rserve/) need access to a static R library. This change enables static library builds.

Fixes #11
