### PR TITLE
Test for correctly signed packages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ dependencies:
 
 test:
   override:
-    - docker run -it -v $(pwd)/packages:/packages gliderlabs/alpine:3.3 sh -c " apk -U add --allow-untrusted --upgrade /packages/builder/x86_64/*.apk"
+    - docker run -it -v $(pwd)/packages:/packages alpine:3.4 sh -c "cp /packages/sgerrand.rsa.pub /etc/apk/keys/ && apk -U add --no-progress --upgrade /packages/builder/x86_64/*.apk"
 
 deployment:
   release:


### PR DESCRIPTION
💁  Given that signed packages are being made available, the process of testing the build should also test that the artifacts which are produced are correctly signed.
