### PR TITLE
Fix public key URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The current installation method for these packages is to pull them in using
 `wget` or `curl` and install the local file with `apk`:
 
     apk --no-cache add ca-certificates wget
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-R/master/sgerrand.rsa.pub
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://github.com/sgerrand/alpine-pkg-R/releases/download/3.3.1-r0/sgerrand.rsa.pub
     wget https://github.com/sgerrand/alpine-pkg-R/releases/download/3.3.1-r0/R-3.3.1-r0.apk
     apk add R-3.3.1-r0.apk
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,10 @@ general:
     - packages
 
 machine:
+  pre:
+    - sudo mv /usr/local/go /usr/local/go-1.6.2
+    - wget -q -O /tmp/go1.7.3.tgz https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz
+    - sudo tar -xzf /tmp/go1.7.3.tgz -C /usr/local
   services:
     - docker
 


### PR DESCRIPTION
💁  The public key on master differs from that stored in the release, which causes the key verification step in apk package installation to fail. Using the key from the release artifacts resolves this issue. This change updates that reference.

```
$ docker run -it alpine sh
/ # apk --no-cache add ca-certificates wget
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/2) Installing ca-certificates (20160104-r4)
(2/2) Installing wget (1.18-r0)
Executing busybox-1.24.2-r11.trigger
Executing ca-certificates-20160104-r4.trigger
OK: 6 MiB in 13 packages
/ # wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://github.com/sgerrand/alpine-pkg-R/releases/download/3.3.1-r0/sgerrand.rsa.pub
/ # wget -q https://github.com/sgerrand/alpine-pkg-R/releases/download/3.3.1-r0/R-3.3.1-r0.apk
/ # apk -U add R-3.3.1-r0.apk
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/14) Installing libbz2 (1.0.6-r5)
(2/14) Installing libssh2 (1.7.0-r0)
(3/14) Installing libcurl (7.50.3-r0)
(4/14) Installing libgcc (5.3.0-r0)
(5/14) Installing libquadmath (5.3.0-r0)
(6/14) Installing libgfortran (5.3.0-r0)
(7/14) Installing libgomp (5.3.0-r0)
(8/14) Installing xz-libs (5.2.2-r1)
(9/14) Installing pcre (8.38-r1)
(10/14) Installing ncurses-terminfo-base (6.0-r7)
(11/14) Installing ncurses-terminfo (6.0-r7)
(12/14) Installing ncurses-libs (6.0-r7)
(13/14) Installing readline (6.3.008-r4)
(14/14) Installing R (3.3.1-r0)
Executing busybox-1.24.2-r11.trigger
OK: 71 MiB in 27 packages
```

Closes #15 #17
